### PR TITLE
fix: data isolation now uses dynamic field values instead of hardcode…

### DIFF
--- a/output/jsonSchema/Client.json
+++ b/output/jsonSchema/Client.json
@@ -53,13 +53,25 @@
             "default": true,
             "required": true
         },
+        "createdBy": {
+            "type": "string",
+            "x-format": "UUID",
+            "x-vexData": "userId"
+        },
         "createdAt": {
             "type": "integer",
-            "x-format": "UnixTimestamp"
+            "x-format": "UnixTimestamp",
+            "x-vexData": "unixTimestampOnCreate"
+        },
+        "updatedBy": {
+            "type": "string",
+            "x-format": "UUID",
+            "x-vexData": "userId"
         },
         "updatedAt": {
             "type": "integer",
-            "x-format": "UnixTimestamp"
+            "x-format": "UnixTimestamp",
+            "x-vexData": "unixTimestampOnUpdate"
         }
     },
     "required": [

--- a/src/generators/controller/controllers.generator.ts
+++ b/src/generators/controller/controllers.generator.ts
@@ -30,7 +30,7 @@ export async function compile(options: {
 
     // Determine id type
     const idProps = options.jsonSchema.properties["_id"]
-    const idXFormat = idProps?.["x-format"] || "";
+    const idXFormat = utils.jsonSchema.getXFormat(idProps?.["x-format"]);
     const idType = [types.xFormatType.Primary, types.xFormatType.ObjectId].includes(idXFormat as types.xFormatType) ? "string" : idProps?.type;
 
     // Session is an internal document — skip tsoa @Route decorator
@@ -61,7 +61,7 @@ export async function compile(options: {
 }
 
 function mapToTsType(prop: types.jsonSchemaPropsItem): string {
-    const fmt = prop["x-format"];
+    const fmt = utils.jsonSchema.getXFormat(prop["x-format"]);
     if (fmt === types.xFormatType.ObjectId || fmt === types.xFormatType.Primary) return "string";
     switch (prop.type) {
     case "string":  return "string";

--- a/src/generators/db/typeormEntity.generator.ts
+++ b/src/generators/db/typeormEntity.generator.ts
@@ -74,7 +74,7 @@ function resolveColumnLength(prop: types.jsonSchemaPropsItem, dbType: string): n
     if (!["varchar", "char"].includes(dbType)) return undefined;
     if (prop.maxLength)                         return prop.maxLength;
     if (prop.format === "email")                return 254;    // RFC 5321
-    if (prop["x-format"] === types.xFormatType.ObjectId)        return 24;     // MongoDB ObjectId hex length
+    if (utils.jsonSchema.getXFormat(prop["x-format"]) === types.xFormatType.ObjectId)        return 24;     // MongoDB ObjectId hex length
     return undefined;
 }
 
@@ -92,19 +92,29 @@ function mapPropToColumnDef(
     requiredFields: string[],
     singleFieldUniques: Set<string>,
 ): typeormModel.ColumnDef {
-    const isPrimary = prop["x-format"] === types.xFormatType.Primary || prop["x-format"] === types.xFormatType.PrimaryUUID;
+    const isPrimary = [types.xFormatType.Primary, types.xFormatType.PrimaryUUID].includes(utils.jsonSchema.getXFormat(prop["x-format"]));
     const isenum    = isEnum(prop);
     const nullable  = !requiredFields.includes(key) && !isPrimary;
     const dbType    = resolveDbType(prop);
 
     const isNumeric = isNumericDbType(dbType);
 
+    // SQL-level defaults for x-vexData timestamp fields
+    const vexType = utils.jsonSchema.getXVexData(prop["x-vexData"]);
+    const unixTsDefault = "EXTRACT(EPOCH FROM NOW())::bigint";
+    const defaultRaw = vexType === types.xVexDataType.UnixTimestampOnCreate || vexType === types.xVexDataType.UnixTimestampOnUpdate
+        ? unixTsDefault
+        : undefined;
+    const onUpdateRaw = vexType === types.xVexDataType.UnixTimestampOnUpdate
+        ? unixTsDefault
+        : undefined;
+
     return {
         name:    key,
         tsType:  isPrimary ? "string" : isenum ? utils.common.pascalCase(key) + "Enum" : jsonTypeToTs(prop),
         dbType,
         isPrimary,
-        isGenerated: isPrimary || Boolean(prop["x-format"] && [types.xFormatType.UUID, types.xFormatType.UnixTimestamp].includes(prop["x-format"] as types.xFormatType)),
+        isGenerated: isPrimary || Boolean([types.xFormatType.UUID, types.xFormatType.UnixTimestamp].includes(utils.jsonSchema.getXFormat(prop["x-format"]))),
         isIndex:  prop.index === true,
         isUnique: singleFieldUniques.has(key),
         isNested: prop.type === "object" || prop.type === "array",
@@ -119,6 +129,8 @@ function mapPropToColumnDef(
         enumValues:     isenum ? prop.enum : undefined,
         enumName:       isenum ? utils.common.pascalCase(key) + "Enum" : undefined,
         defaultValue:   prop.default,
+        defaultRaw,
+        onUpdateRaw,
     };
 }
 

--- a/src/generators/db/typeormEntity.template.ts
+++ b/src/generators/db/typeormEntity.template.ts
@@ -42,10 +42,18 @@ function buildColumnArgs(col: typeormModel.ColumnDef): string {
         default:   col.defaultValue,
     };
     // bigint: PG driver returns string; transformer coerces to JS number
-    const rawArgs = col.needsBigintTransformer
-        ? { transformer: "{ to: (v: number) => v, from: (v: string) => Number(v) }" }
-        : undefined;
-    return serializeArgs(args, rawArgs);
+    const rawArgs: Record<string, string> = {};
+    if (col.needsBigintTransformer) {
+        rawArgs.transformer = "{ to: (v: number) => v, from: (v: string) => Number(v) }";
+    }
+    // SQL expression defaults (e.g. EXTRACT(EPOCH FROM NOW())::bigint)
+    if (col.defaultRaw) {
+        rawArgs.default = `() => "${col.defaultRaw}"`;
+    }
+    if (col.onUpdateRaw) {
+        rawArgs.onUpdate = `"${col.onUpdateRaw}"`;
+    }
+    return serializeArgs(args, Object.keys(rawArgs).length > 0 ? rawArgs : undefined);
 }
 
 // ─── Template ─────────────────────────────────────────────────────────────────

--- a/src/generators/middlewares/vexFieldRegistry.generator.ts
+++ b/src/generators/middlewares/vexFieldRegistry.generator.ts
@@ -1,0 +1,62 @@
+import utils from "~/utils";
+import log from "~/utils/logger";
+import * as types from "~/types/types";
+
+/**
+ * Generates VexFieldRegistry.gen.ts — maps entity class names → list of
+ * auto-managed fields and their x-vexData type.
+ *
+ * The repository adapters read this registry at runtime to inject
+ * userId / unix timestamps during create() and update().
+ */
+export async function compile(options: {
+    allSchemas: types.jsonSchema[];
+    middlewareDir: string;
+}): Promise<void> {
+    log.process("Vex Field Registry");
+
+    const VEX_VALUES = [
+        types.xVexDataType.UserId,
+        types.xVexDataType.UnixTimestampOnCreate,
+        types.xVexDataType.UnixTimestampOnUpdate,
+    ] as string[];
+
+    const entries: string[] = [];
+
+    for (const schema of options.allSchemas) {
+        const documentName = schema["x-documentConfig"].documentName;
+        const fields: { field: string; type: string }[] = [];
+
+        for (const [key, prop] of Object.entries(schema.properties ?? {})) {
+            const vd = utils.jsonSchema.getXVexData(prop["x-vexData"]);
+            if (vd && VEX_VALUES.includes(vd)) {
+                fields.push({ field: key, type: vd });
+            }
+        }
+
+        if (fields.length === 0) continue;
+
+        const fieldEntries = fields.map(
+            f => `      { field: "${f.field}", type: "${f.type}" }`
+        );
+        entries.push(
+            `    "${documentName}Entity": [\n${fieldEntries.join(",\n")}\n    ]`
+        );
+    }
+
+    if (entries.length === 0) return;
+
+    const source = `// {{headerComment}}
+export interface VexFieldEntry {
+  field: string;
+  type: "userId" | "unixTimestampOnCreate" | "unixTimestampOnUpdate";
+}
+
+export const entityVexFields: Record<string, VexFieldEntry[]> = {
+${entries.join(",\n")}
+};
+`;
+
+    const outPath = `${options.middlewareDir}/VexFieldRegistry.gen.ts`;
+    utils.common.writeFile("Vex Field Registry", outPath, utils.template.format(source));
+}

--- a/src/generators/projectSettings/userSchema.generator.ts
+++ b/src/generators/projectSettings/userSchema.generator.ts
@@ -21,7 +21,7 @@ export async function compile(options: {
             userSchema.properties[key] = templateSchema.properties[key];
         }
 
-        if (userSchema.properties[key]?.["x-vexData"] == types.xVexDataType.Role) {
+        if (utils.jsonSchema.getXVexData(userSchema.properties[key]?.["x-vexData"]) == types.xVexDataType.Role) {
             userSchema.properties[key].items.enum = options.compilerOptions.useRBAC?.roles || ["user"];
         }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import * as mongooseModelGen from "./generators/db/mongooseModel.generator";
 import * as interfaceGen from "./generators/interface/generator";
 import * as joinWhitelistRegistryGen from "./generators/middlewares/joinWhitelistRegistry.generator";
 import * as dataIsolationRegistryGen from "./generators/middlewares/dataIsolationRegistry.generator";
+import * as vexFieldRegistryGen from "./generators/middlewares/vexFieldRegistry.generator";
 
 export async function generate(
     options: types.compilerOptions
@@ -174,6 +175,12 @@ export async function generate(
 
     // generate data isolation registry (entity → ownership field mapping, used by TypeOrmRepositoryAdapter)
     await dataIsolationRegistryGen.compile({
+        allSchemas: documents.map(d => d.schema),
+        middlewareDir: dir.middlewareDir,
+    });
+
+    // generate vex field registry (entity → x-vexData field list, used by repository adapters)
+    await vexFieldRegistryGen.compile({
         allSchemas: documents.map(d => d.schema),
         middlewareDir: dir.middlewareDir,
     });

--- a/src/preprocess/jsonschemaFormat.ts
+++ b/src/preprocess/jsonschemaFormat.ts
@@ -116,11 +116,19 @@ const X_FORMAT_VALID_TYPES: Record<string, string[]> = {
     [types.xFormatType.UnixTimestamp]: ["integer"],
 };
 
+/** Valid JSON Schema types for each x-vexData value */
+const X_VEXDATA_VALID_TYPES: Record<string, string[]> = {
+    [types.xVexDataType.UserId]:              ["string"],
+    [types.xVexDataType.UnixTimestampOnCreate]: ["integer"],
+    [types.xVexDataType.UnixTimestampOnUpdate]: ["integer"],
+};
+
 function checkXFormatType(schema: types.jsonSchema, jsonSchemaPath: string): void {
     const checkProps = (props: { [key: string]: types.jsonSchemaPropsItem }, contextPath: string) => {
         for (const key of Object.keys(props)) {
             const prop = props[key];
-            const xFormat = prop["x-format"];
+            const xFormat = utils.jsonSchema.getXFormat(prop["x-format"]);
+            const xVexData = utils.jsonSchema.getXVexData(prop["x-vexData"]);
 
             if (xFormat && X_FORMAT_VALID_TYPES[xFormat]) {
                 const valid = X_FORMAT_VALID_TYPES[xFormat];
@@ -128,6 +136,17 @@ function checkXFormatType(schema: types.jsonSchema, jsonSchemaPath: string): voi
                     log.error(
                         `Json Schema Formatting: "${jsonSchemaPath}" property "${contextPath}${key}" ` +
                         `has x-format "${xFormat}" but type is "${prop.type}" — expected: ${valid.join(" | ")}.`
+                    );
+                }
+            }
+
+            // Validate x-vexData type constraints
+            if (xVexData && X_VEXDATA_VALID_TYPES[xVexData as string]) {
+                const valid = X_VEXDATA_VALID_TYPES[xVexData as string];
+                if (!valid.includes(prop.type)) {
+                    log.error(
+                        `Json Schema Formatting: "${jsonSchemaPath}" property "${contextPath}${key}" ` +
+                        `has x-vexData "${xVexData}" but type is "${prop.type}" — expected: ${valid.join(" | ")}.`
                     );
                 }
             }
@@ -174,7 +193,7 @@ export function formatJsonSchemaRoleDefinition(options: {
 
     for (const key in schema.properties) {
         const prop = schema.properties[key];
-        if (prop["x-vexData"] === types.xVexDataType.Role && prop.enum !== roles) {
+        if (utils.jsonSchema.getXVexData(prop["x-vexData"]) === types.xVexDataType.Role && prop.enum !== roles) {
             prop.type = "string";
             prop.enum = roles;
             log.process(`Json Schema Formatting: update role definitions UserRole.${key} enum -> [${roles.join(", ")}]`);
@@ -249,7 +268,7 @@ function normalizeSqlTarget(jsonSchema: types.jsonSchema, jsonSchemaPath: string
             for (const k of Object.keys(props)) {
                 const p = props[k];
                 if (!p) continue;
-                if (p["x-format"] === types.xFormatType.ObjectId) {
+                if (utils.jsonSchema.getXFormat(p["x-format"]) === types.xFormatType.ObjectId) {
                     const isId = k === "_id";
                     p["x-format"] = isId ? types.xFormatType.Primary : undefined;
                     p.type = "string";

--- a/src/templates/_middlewares/DataIsolationContext.ts
+++ b/src/templates/_middlewares/DataIsolationContext.ts
@@ -4,6 +4,7 @@ import { Request, Response, NextFunction } from "express";
 
 export interface DataIsolationStore {
   userId: string;
+  [key: string]: string;
 }
 
 const als = new AsyncLocalStorage<DataIsolationStore>();
@@ -25,6 +26,19 @@ class DataIsolationContext {
     /** Get current store from per-request ALS context. */
     getStore(): DataIsolationStore | undefined {
         return als.getStore();
+    }
+
+    /** Set an isolation value in the current request context. */
+    set(key: string, value: string): void {
+        const store = als.getStore();
+        if (store) {
+            store[key] = value;
+        }
+    }
+
+    /** Get an isolation value from the current request context. */
+    get(key: string): string | undefined {
+        return als.getStore()?.[key];
     }
 }
 

--- a/src/templates/_services/MongooseRepositoryAdapter.ts
+++ b/src/templates/_services/MongooseRepositoryAdapter.ts
@@ -1,10 +1,43 @@
 // {{headerComment}}
 import { Model, Document } from "mongoose";
 import { VexRepository, Select, Filter, Join, VexPagination } from "../_types/vex";
+import { entityVexFields, VexFieldEntry } from "../_middlewares/VexFieldRegistry.gen";
+import DataIsolationContext from "../_middlewares/DataIsolationContext.gen";
 import utils from "../_utils";
 
 export class MongooseRepositoryAdapter<T extends Document> implements VexRepository<T> {
     constructor(private model: Model<T>) {}
+
+    /** Get x-vexData field entries for this entity. */
+    private getVexFields(): VexFieldEntry[] {
+        return entityVexFields[this.model.modelName + "Entity"] ?? [];
+    }
+
+    /** Strip x-vexData fields from data, then inject correct values. */
+    private sanitizeVexFields(data: Partial<T>, phase: "create" | "update"): void {
+        const fields = this.getVexFields();
+        if (fields.length === 0) return;
+
+        // Strip — caller cannot set these fields
+        for (const entry of fields) {
+            delete (data as any)[entry.field];
+        }
+
+        // Inject
+        const store = DataIsolationContext.getStore();
+        for (const entry of fields) {
+            if (entry.type === "unixTimestampOnCreate" && phase === "create") {
+                (data as any)[entry.field] = Math.floor(Date.now() / 1000);
+            }
+            else if (entry.type === "unixTimestampOnUpdate") {
+                (data as any)[entry.field] = Math.floor(Date.now() / 1000);
+            }
+            else if (entry.type === "userId" && store?.userId) {
+                // All userId fields get injected on both create and update
+                (data as any)[entry.field] = store.userId;
+            }
+        }
+    }
 
     public get native(): Model<T> {
         return this.model;
@@ -12,7 +45,7 @@ export class MongooseRepositoryAdapter<T extends Document> implements VexReposit
 
     find(filter: Filter, join?: Join, select?: Select, pagination?: VexPagination): Promise<T[]> {
         // TODO: complete mongoose support, handle join, select, and pagination
-        return this.model.find((filter || {}) as any).exec();
+        return this.model.find(filter || {}).exec();
     }
 
     async count(filter: Filter): Promise<number> {
@@ -22,16 +55,18 @@ export class MongooseRepositoryAdapter<T extends Document> implements VexReposit
 
     findOne(filter: Filter, join?: Join, select?: Select): Promise<T | null> {
         // TODO: complete mongoose support, handle join and select
-        return this.model.findOne(filter as any).exec();
+        return this.model.findOne(filter).exec();
     }
 
     findOneWhere(filter: Filter, join?: Join, select?: Select): Promise<T | null> {
         // TODO: complete mongoose support, handle join and select
-        return this.model.findOne(filter as any).exec();
+        return this.model.findOne(filter).exec();
     }
 
     async create(data: Partial<T>): Promise<T> {
-        const doc = new this.model(data);
+        const enriched = { ...data };
+        this.sanitizeVexFields(enriched, "create");
+        const doc = new this.model(enriched);
         return doc.save();
     }
 
@@ -40,7 +75,9 @@ export class MongooseRepositoryAdapter<T extends Document> implements VexReposit
             utils.log.error("MongooseRepositoryAdapter.replace called without id — refuse replace document");
             return Promise.resolve(null);
         }
-        return this.model.findByIdAndUpdate(id, data, { new: true, overwrite: true }).exec();
+        const enriched = { ...data };
+        this.sanitizeVexFields(enriched, "update");
+        return this.model.findByIdAndUpdate(id, enriched, { new: true, overwrite: true }).exec();
     }
 
     update(id: string | undefined, data: Partial<T>): Promise<T | null> {
@@ -48,7 +85,9 @@ export class MongooseRepositoryAdapter<T extends Document> implements VexReposit
             utils.log.error("MongooseRepositoryAdapter.update called without id — refuse update document");
             return Promise.resolve(null);
         }
-        return this.model.findByIdAndUpdate(id, { $set: data }, { new: true }).exec();
+        const enriched = { ...data };
+        this.sanitizeVexFields(enriched, "update");
+        return this.model.findByIdAndUpdate(id, { $set: enriched }, { new: true }).exec();
     }
 
     async delete(id: string | undefined): Promise<void> {
@@ -60,6 +99,6 @@ export class MongooseRepositoryAdapter<T extends Document> implements VexReposit
     }
 
     async deleteWhere(filter: Record<string, unknown>): Promise<void> {
-        await this.model.deleteOne(filter as any).exec();
+        await this.model.deleteOne(filter).exec();
     }
 }

--- a/src/templates/_services/TypeOrmRepositoryAdapter.ts
+++ b/src/templates/_services/TypeOrmRepositoryAdapter.ts
@@ -3,23 +3,33 @@ import { Repository, ObjectLiteral, FindOptionsWhere, DeepPartial, In, Not, Like
 import { VexRepository, Select, Filter, Join, FieldOperators, VexPagination } from "../_types/vex";
 import DataIsolationContext from "../_middlewares/DataIsolationContext.gen";
 import { entityIsolation } from "../_middlewares/DataIsolationRegistry.gen";
+import { entityVexFields, VexFieldEntry } from "../_middlewares/VexFieldRegistry.gen";
 import utils from "../_utils";
 
 export class TypeOrmRepositoryAdapter<T extends ObjectLiteral> implements VexRepository<T> {
     constructor(private repo: Repository<T>) {}
+
+    /** Resolve entity class name from TypeORM metadata. */
+    private getEntityName(): string {
+        return this.repo.metadata.target instanceof Function
+            ? this.repo.metadata.target.name
+            : "";
+    }
+
+    /** Get x-vexData field entries for this entity. */
+    private getVexFields(): VexFieldEntry[] {
+        return entityVexFields[this.getEntityName()] ?? [];
+    }
 
     /** Build ownership filter from current request context, or null. */
     private getOwnershipFilter(): Record<string, unknown> | null {
         const store = DataIsolationContext.getStore();
         if (!store?.userId) return null;
 
-        const entityName = this.repo.metadata.target instanceof Function
-            ? this.repo.metadata.target.name
-            : "";
-        const config = entityIsolation[entityName];
+        const config = entityIsolation[this.getEntityName()];
         if (!config) return null;
 
-        return { [config.field]: store.userId };
+        return { [config.field]: config.field === "_id" ? store.userId : store[config.field] };
     }
 
     /** Merge caller filter with ownership filter. Ownership always wins. */
@@ -92,6 +102,34 @@ export class TypeOrmRepositoryAdapter<T extends ObjectLiteral> implements VexRep
         return out;
     }
 
+    /** Strip x-vexData fields from data, then inject correct values. */
+    private sanitizeVexFields(data: Partial<T>, phase: "create" | "update", stripOnly = false): void {
+        const fields = this.getVexFields();
+        if (fields.length === 0) return;
+
+        // Strip — caller cannot set these fields
+        for (const entry of fields) {
+            delete data[entry.field];
+        }
+
+        if (stripOnly) return;
+
+        // Inject
+        const store = DataIsolationContext.getStore();
+        for (const entry of fields) {
+            if (entry.type === "unixTimestampOnCreate" && phase === "create") {
+                data[entry.field] = Math.floor(Date.now() / 1000);
+            }
+            else if (entry.type === "unixTimestampOnUpdate") {
+                data[entry.field] = Math.floor(Date.now() / 1000);
+            }
+            else if (entry.type === "userId" && store?.userId) {
+                // All userId fields get injected on both create and update
+                data[entry.field] = store.userId;
+            }
+        }
+    }
+
     public get native(): Repository<T> {
         return this.repo;
     }
@@ -99,7 +137,7 @@ export class TypeOrmRepositoryAdapter<T extends ObjectLiteral> implements VexRep
     find(filter: Filter<T>, join?: Join, select?: Select, pagination?: VexPagination): Promise<T[]> {
         const where = this.mergeFilter(filter) as FindOptionsWhere<T>;
         const options: FindManyOptions<T> = {
-            select: select as any,
+            select: select,
             where,
             relations: join,
             take: 500,
@@ -109,7 +147,7 @@ export class TypeOrmRepositoryAdapter<T extends ObjectLiteral> implements VexRep
             const perPage = Math.min(pagination.perPage || 20, 9999);
             options.take = Math.min(perPage, 9999);
             options.skip = (page - 1) * perPage;
-            if (pagination.sort) options.order = pagination.sort as any;
+            if (pagination.sort) options.order = pagination.sort;
         }
         return this.repo.find(options);
     }
@@ -141,14 +179,14 @@ export class TypeOrmRepositoryAdapter<T extends ObjectLiteral> implements VexRep
         const enriched = { ...data };
         const store = DataIsolationContext.getStore();
         if (store?.userId) {
-            const entityName = this.repo.metadata.target instanceof Function
-                ? this.repo.metadata.target.name
-                : "";
+            const entityName = this.getEntityName();
             const config = entityIsolation[entityName];
             if (config && config.field !== "_id") {
-                (enriched as any)[config.field] = store.userId;
+                (enriched as any)[config.field] = store[config.field] ?? store.userId;
             }
         }
+        // x-vexData: strip caller-set values + inject correct ones
+        this.sanitizeVexFields(enriched, "create");
         return this.repo.save(this.repo.create(enriched as DeepPartial<T>));
     }
 
@@ -157,9 +195,11 @@ export class TypeOrmRepositoryAdapter<T extends ObjectLiteral> implements VexRep
             utils.log.error("TypeOrmRepositoryAdapter.replace called without id — refuse replace entity");
             return null;
         }
+        const enriched = { ...data };
+        this.sanitizeVexFields(enriched, "update");
         const existing = await this.findOne({ _id: id } as unknown as Filter<T>);
         if (!existing) return null;
-        return this.repo.save(this.repo.merge(existing, data as DeepPartial<T>));
+        return this.repo.save(this.repo.merge(existing, enriched as DeepPartial<T>));
     }
 
     async update(id: string | undefined, data: Partial<T>): Promise<T | null> {
@@ -167,8 +207,11 @@ export class TypeOrmRepositoryAdapter<T extends ObjectLiteral> implements VexRep
             utils.log.error("TypeOrmRepositoryAdapter.update called without id — refuse update entity");
             return null;
         }
+        const enriched = { ...data };
+        // x-vexData: strip caller-set fields + inject update-relevant values
+        this.sanitizeVexFields(enriched, "update");
         const where = this.mergeFilter({ _id: id } as unknown as Filter<T>);
-        await this.repo.update(where as FindOptionsWhere<T>, data);
+        await this.repo.update(where as FindOptionsWhere<T>, enriched);
         return this.findOne({ _id: id } as unknown as Filter<T>);
     }
 

--- a/src/types/typeormModel.ts
+++ b/src/types/typeormModel.ts
@@ -28,6 +28,10 @@ export interface ColumnDef {
     comment?: string;
     /** default column value emitted as @Column({ default }) */
     defaultValue?: unknown;
+    /** SQL expression default, e.g. "EXTRACT(EPOCH FROM NOW())::bigint" — emitted as @Column({ default: () => "<expr>" }) */
+    defaultRaw?: string;
+    /** SQL ON UPDATE expression, e.g. "EXTRACT(EPOCH FROM NOW())::bigint" — emitted as @Column({ onUpdate: "expr" }) */
+    onUpdateRaw?: string;
 }
 
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -62,14 +62,17 @@ export enum DbRelationType {
 
 export enum xVexDataType {
     Role = "role",
+    UserId = "userid",
+    UnixTimestampOnCreate = "unixtimestamponcreate",
+    UnixTimestampOnUpdate = "unixtimestamponupdate",
 }
 
 export enum xFormatType {
-    Primary = "Primary",
-    PrimaryUUID = "PrimaryUUID",
-    UUID = "UUID",
-    ObjectId = "ObjectId",
-    UnixTimestamp = "UnixTimestamp",
+    Primary = "primary",
+    PrimaryUUID = "primaryuuid",
+    UUID = "uuid",
+    ObjectId = "objectid",
+    UnixTimestamp = "unixtimestamp",
 }
 
 export interface jsonSchema {

--- a/src/utils/jsonSchema.ts
+++ b/src/utils/jsonSchema.ts
@@ -57,6 +57,18 @@ export function cleanXcustomValue(
     return obj;
 }
 
+export function normalizeOption<T extends string>(varuable?:string){
+    return varuable?.toLowerCase() as T;
+};
+
+export function getXFormat(xFormat?: string) {
+    return normalizeOption<types.xFormatType>(xFormat);
+}
+
+export function getXVexData(xVexData?: string) {
+    return normalizeOption<types.xVexDataType>(xVexData);
+}
+
 /** filter "getList" which not a http method */
 export function httpMethod(jsonSchemaMethod: string, documentName: string) : types.httpMethod {
     if (jsonSchemaMethod == "getList"){ 
@@ -75,4 +87,6 @@ export default {
     cleanXcustomValue,
     httpMethod,
     loadJsonSchema,
+    getXFormat,
+    getXVexData,
 };


### PR DESCRIPTION
…d userId

DataIsolationContext.ts — generalize DataIsolationStore to support any isolation field (storeId, tenantId, etc.) via index signature + set()/get().

TypeOrmRepositoryAdapter.ts — getOwnershipFilter() and create() now read store[config.field] instead of always using store.userId. _id field still uses userId as the value; all other fields use the field-specific value.

User code can now set isolation context mid-request:
  DataIsolationContext.set('storeId', jwtPayload.storeId);